### PR TITLE
Monorepo 移行 Phase 5: Docker 環境の更新

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - MESH_AWS_REGION
       - MESH_DATA_UPDATE_INTERVAL_MS
       - MESH_EVENT_BATCH_INTERVAL_MS
-    working_dir: /app/gui/smalruby3-gui
+    working_dir: /app/gui/smalruby3-editor/packages/scratch-gui
     shm_size: '4gb'
     command: npm start
     volumes:
@@ -25,11 +25,8 @@ services:
         source: root_npm
         target: /root/.npm
       - type: volume
-        source: scratch-vm_node_modules
-        target: /app/gui/scratch-vm/node_modules
-      - type: volume
-        source: smalruby3-gui_node_modules
-        target: /app/gui/smalruby3-gui/node_modules
+        source: smalruby3-editor_node_modules
+        target: /app/gui/smalruby3-editor/node_modules
     ports:
       - 0.0.0.0:8601:8601
     logging:
@@ -56,5 +53,4 @@ services:
 
 volumes:
   root_npm:
-  scratch-vm_node_modules:
-  smalruby3-gui_node_modules:
+  smalruby3-editor_node_modules:

--- a/gui/Dockerfile
+++ b/gui/Dockerfile
@@ -44,9 +44,6 @@ ENV NODE_OPTIONS --max-old-space-size=4000
 
 EXPOSE 8601
 
-# node_modulesをvolumeとしてマウントするが、scratch-vmのnpm linkは保持されないため、このタイミングで作成しておく
-RUN mkdir -p /usr/local/lib/node_modules/ && ln -sf ../../../../app/gui/scratch-vm /usr/local/lib/node_modules/scratch-vm
-
 COPY entrypoint.sh /app/gui/entrypoint.sh
 RUN chmod +x /app/gui/entrypoint.sh
 ENTRYPOINT ["/app/gui/entrypoint.sh"]

--- a/gui/entrypoint.sh
+++ b/gui/entrypoint.sh
@@ -1,22 +1,12 @@
 #! /bin/sh -e
 
-if [ ! -e /app/gui/built-scratch-vm ]; then
+if [ ! -e /app/gui/built-monorepo ]; then
   (
-    cd /app/gui/scratch-vm
-    npm ci
-    npm run build
-    npm link
-    touch /app/gui/built-scratch-vm
-  )
-fi
-
-if [ ! -e /app/gui/built-smalruby3-gui ]; then
-  (
-    cd /app/gui/smalruby3-gui
-    npm ci
-    npm link scratch-vm
-    npm run build
-    touch /app/gui/built-smalruby3-gui
+    cd /app/gui/smalruby3-editor
+    npm install
+    cd packages/scratch-gui
+    npm run setup:opal
+    touch /app/gui/built-monorepo
   )
 fi
 


### PR DESCRIPTION
Monorepo 移行の Phase 5 として、Docker 環境を `gui/smalruby3-editor` を使用するように更新しました。

## 修正内容
- `docker-compose.yml`: `working_dir` を `packages/scratch-gui` に変更し、Monorepo 用の `node_modules` ボリュームを追加しました。
- `gui/Dockerfile`: 不要になった `npm link` 用のシンボリックリンク作成を削除しました。
- `gui/entrypoint.sh`: Monorepo のルートで `npm install` を実行し、`packages/scratch-gui` で `setup:opal` を実行するように変更しました。

詳細は Issue #37 を参照してください。