### PR TITLE
feat: CI/CD updates for monorepo migration (Phase 6)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,113 @@
+name: CI/CD
+
+on:
+  pull_request:
+  push:
+    branches: [main, master, develop, hotfix/*]
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pages: write
+
+env:
+  NODE_OPTIONS: --max-old-space-size=4000
+  DETECT_CHROMEDRIVER_VERSION: "true"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    defaults:
+      run:
+        working-directory: gui/smalruby3-editor
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: gui/smalruby3-editor/package-lock.json
+          node-version-file: "gui/smalruby3-editor/.nvmrc"
+      - name: Install Dependencies
+        run: npm ci
+      - name: Create Test Results Directory
+        run: |
+          mkdir -p packages/scratch-gui/test-results
+          mkdir -p packages/scratch-vm/test-results
+      - name: Lint
+        run: npm run lint
+      - name: Unit tests
+        run: |
+          npm run test:unit:gui -- --reporters="default" --reporters="jest-junit"
+          npm run test:unit:vm -- -R junit > packages/scratch-vm/test-results/unit.xml
+      - name: Store Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-unit
+          path: |
+            gui/smalruby3-editor/packages/scratch-gui/test-results
+            gui/smalruby3-editor/packages/scratch-vm/test-results
+
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: gui/smalruby3-editor
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: gui/smalruby3-editor/package-lock.json
+          node-version-file: "gui/smalruby3-editor/.nvmrc"
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build
+        env:
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          MESH_GRAPHQL_ENDPOINT: ${{ secrets.MESH_GRAPHQL_ENDPOINT }}
+          MESH_API_KEY: ${{ secrets.MESH_API_KEY }}
+          MESH_AWS_REGION: ${{ secrets.MESH_AWS_REGION }}
+        run: npm run build
+      - name: Create Test Results Directory
+        run: |
+          mkdir -p packages/scratch-gui/test-results
+          mkdir -p packages/scratch-vm/test-results
+      - name: Integration tests
+        if: github.event_name == 'pull_request'
+        run: |
+          npm run test:integration:gui -- --reporters="default" --reporters="jest-junit"
+          npm run test:integration:vm -- -R junit > packages/scratch-vm/test-results/integration.xml
+      - name: Store Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-integration
+          path: |
+            gui/smalruby3-editor/packages/scratch-gui/test-results
+            gui/smalruby3-editor/packages/scratch-vm/test-results
+      - name: Store Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: gui/smalruby3-editor/packages/scratch-gui/build
+      - name: Prepare deployment files
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        run: touch packages/scratch-gui/build/.nojekyll
+      - name: Deploy to smalruby.app
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
+        if: |
+          github.event_name == 'push' &&
+          (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        with:
+          deploy_key: ${{ secrets.SMALRUBY_APP_DEPLOY_KEY }}
+          publish_dir: gui/smalruby3-editor/packages/scratch-gui/build
+          full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
+          cname: smalruby.app
+          external_repository: smalruby/smalruby.app

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,15 @@
+name: Lint commit messages
+on: [pull_request]
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -191,6 +191,8 @@ Note: The smalruby3-gui package.json contains merge conflict markers from upstre
 
 **IMPORTANT**: All GitHub operations (issues, pull requests, comments, etc.) must be performed against the Smalruby organization repositories, NOT the upstream Scratch Foundation repositories. Always use the `gh` command for GitHub access.
 
+**IMPORTANT: Message Escaping Rule**: When using the `gh` command to create issues or pull requests, always store the commit message or PR description in a temporary file first, and then use the `-F` (or `--body-file`) and `-F` (or `--title-file`) flags. Do not pass long or complex messages directly as command-line arguments to avoid shell escaping issues.
+
 ### Correct Repository URLs
 - **scratch-vm**: https://github.com/smalruby/scratch-vm
 - **smalruby3-gui**: https://github.com/smalruby/smalruby3-gui


### PR DESCRIPTION
## Summary
This PR implements Phase 6 of the monorepo migration by consolidating and updating the CI/CD workflows.

## Changes
- Created root-level `.github/workflows/ci-cd.yml` and `.github/workflows/commitlint.yml`.
- Unified tests and checks for `scratch-gui` and `scratch-vm` into a single workflow.
- Configured automatic deployment to `smalruby.app` for `develop`, `main`, and `master` branches.
- Updated `gui/smalruby3-editor` submodule reference to include necessary CI scripts (see smalruby/smalruby3-editor#23).
- Added convenience scripts to `gui/smalruby3-editor/package.json` for workspace-specific operations.

## Tasks Covered
- [x] 6.1. GitHub Actions ワークフローの作成
- [x] 6.2. Monorepo ビルドプロセスへの対応
- [x] 6.3. デプロイワークフローの更新
- [x] 6.4. テスト実行の調整
- [x] 6.5. Workflow トリガーの設定

Closes #40

🤖 Generated with [Gemini Code](https://gemini.google.com/code)
